### PR TITLE
Fix Katex SVG symbols not rendering namespace issue

### DIFF
--- a/.changeset/fair-timers-press.md
+++ b/.changeset/fair-timers-press.md
@@ -1,0 +1,5 @@
+---
+"svelte-exmarkdown": patch
+---
+
+Fix Katex SVG symbols not rendering namespace issue

--- a/src/lib/Element/Element.svelte
+++ b/src/lib/Element/Element.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import ElementSvg from './ElementSVG.svelte';
+	export let component: string;
+</script>
+
+{#if component === 'svg' || component === 'path'}
+	<ElementSvg {component} {...$$restProps}><slot /></ElementSvg>
+{:else}
+	<svelte:element this={component} {...$$restProps}>
+		<slot />
+	</svelte:element>
+{/if}

--- a/src/lib/Element/ElementSVG.svelte
+++ b/src/lib/Element/ElementSVG.svelte
@@ -1,0 +1,9 @@
+<svelte:options namespace="svg" />
+
+<script lang="ts">
+	export let component: string;
+</script>
+
+<svelte:element this={component} {...$$restProps}>
+	<slot />
+</svelte:element>

--- a/src/lib/Renderer.svelte
+++ b/src/lib/Renderer.svelte
@@ -7,6 +7,7 @@
 	import type { HastNode } from './types';
 	import { resolveComponent } from './utils';
 	export let astNode: HastNode;
+	import Element from './Element/Element.svelte';
 
 	const components = getComponentsMap();
 
@@ -23,14 +24,14 @@
 		resolveComponent(
 			$components,
 			astNode.tagName
-		)}{#if typeof component === 'string'}{#if Array.isArray(astNode.children) && astNode.children.length !== 0}<svelte:element
-				this={component}
+		)}{#if typeof component === 'string'}{#if Array.isArray(astNode.children) && astNode.children.length !== 0}<Element
+				component={component}
 				{...astNode.properties}
 				>{#each astNode.children as child}<svelte:self
 						astNode={child}
-					/>{/each}</svelte:element
-			>{:else}<svelte:element
-				this={component}
+					/>{/each}</Element
+			>{:else}<Element
+				component={component}
 				{...astNode.properties}
 			/>{/if}{:else if component !== null}{#if Array.isArray(astNode.children) && astNode.children.length !== 0}<svelte:component
 				this={component}

--- a/src/lib/Renderer.svelte
+++ b/src/lib/Renderer.svelte
@@ -25,13 +25,13 @@
 			$components,
 			astNode.tagName
 		)}{#if typeof component === 'string'}{#if Array.isArray(astNode.children) && astNode.children.length !== 0}<Element
-				component={component}
+				{component}
 				{...astNode.properties}
 				>{#each astNode.children as child}<svelte:self
 						astNode={child}
 					/>{/each}</Element
 			>{:else}<Element
-				component={component}
+				{component}
 				{...astNode.properties}
 			/>{/if}{:else if component !== null}{#if Array.isArray(astNode.children) && astNode.children.length !== 0}<svelte:component
 				this={component}

--- a/src/tests/Markdown.test.ts
+++ b/src/tests/Markdown.test.ts
@@ -311,3 +311,27 @@ describe('HTML', () => {
 		);
 	});
 });
+
+describe('SVG', () => {
+	afterEach(() => cleanup());
+
+	it('should render ElementSVG if svg is used', () => {
+		const { container } = render(Markdown, {
+			md: '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+			plugins: [{ rehypePlugin: rehypeRaw }]
+		});
+		expect(container.innerHTML).toMatchInlineSnapshot(
+			'"<div><p><svg xmlns=\\"http://www.w3.org/2000/svg\\"></svg><!--<ElementSVG>--><!--<Element>--><!--<Renderer>--></p><!--<Element>--><!--<Renderer>--><!--<Renderer>--><!--<Markdown>--></div>"'
+		);
+	});
+
+	it('should render ElementSVG if path is used', () => {
+		const { container } = render(Markdown, {
+			md: '<path d="M1"></path>',
+			plugins: [{ rehypePlugin: rehypeRaw }]
+		});
+		expect(container.innerHTML).toMatchInlineSnapshot(
+			'"<div><p><path d=\\"M1\\"></path><!--<ElementSVG>--><!--<Element>--><!--<Renderer>--></p><!--<Element>--><!--<Renderer>--><!--<Renderer>--><!--<Markdown>--></div>"'
+		);
+	});
+});

--- a/src/tests/Markdown.test.ts
+++ b/src/tests/Markdown.test.ts
@@ -90,8 +90,8 @@ describe('Markdown(CommonMark)', () => {
 		el = screen.getByText('world');
 		expect(el.tagName.toLowerCase()).toBe('p');
 		expect(el.parentElement?.innerHTML).toMatchInlineSnapshot(`
-			"<p>hello<!--<Renderer>--></p><!--<Renderer>-->
-			<!--<Renderer>--><p>world<!--<Renderer>--></p><!--<Renderer>--><!--<Renderer>--><!--<Markdown>-->"
+			"<p>hello<!--<Renderer>--></p><!--<Element>--><!--<Renderer>-->
+			<!--<Renderer>--><p>world<!--<Renderer>--></p><!--<Element>--><!--<Renderer>--><!--<Renderer>--><!--<Markdown>-->"
 		`);
 	});
 
@@ -103,7 +103,7 @@ describe('Markdown(CommonMark)', () => {
 		el = screen.getByText('bold2');
 		expect(el.tagName.toLowerCase()).toBe('strong');
 		expect(el.parentElement?.innerHTML).toMatchInlineSnapshot(
-			'"test <!--<Renderer>--><strong>bold1<!--<Renderer>--></strong><!--<Renderer>--> test <!--<Renderer>--><strong>bold2<!--<Renderer>--></strong><!--<Renderer>-->"'
+			'"test <!--<Renderer>--><strong>bold1<!--<Renderer>--></strong><!--<Element>--><!--<Renderer>--> test <!--<Renderer>--><strong>bold2<!--<Renderer>--></strong><!--<Element>--><!--<Renderer>-->"'
 		);
 	});
 
@@ -115,7 +115,7 @@ describe('Markdown(CommonMark)', () => {
 		el = screen.getByText('italic2');
 		expect(el.tagName.toLowerCase()).toBe('em');
 		expect(el.parentElement?.innerHTML).toMatchInlineSnapshot(
-			'"test <!--<Renderer>--><em>italic1<!--<Renderer>--></em><!--<Renderer>--> test <!--<Renderer>--><em>italic2<!--<Renderer>--></em><!--<Renderer>-->"'
+			'"test <!--<Renderer>--><em>italic1<!--<Renderer>--></em><!--<Element>--><!--<Renderer>--> test <!--<Renderer>--><em>italic2<!--<Renderer>--></em><!--<Element>--><!--<Renderer>-->"'
 		);
 	});
 
@@ -128,14 +128,14 @@ describe('Markdown(CommonMark)', () => {
 		expect((el as HTMLAnchorElement).href).toBe('https://ssssota.github.io/');
 		expect(el.textContent).toBe('link');
 		expect(el.parentElement?.innerHTML).toMatchInlineSnapshot(
-			'"test <!--<Renderer>--><a href=\\"https://ssssota.github.io/\\">link<!--<Renderer>--></a><!--<Renderer>-->"'
+			'"test <!--<Renderer>--><a href=\\"https://ssssota.github.io/\\">link<!--<Renderer>--></a><!--<Element>--><!--<Renderer>-->"'
 		);
 
 		ctx.rerender({ md: 'test [link](https://ssssota.github.io "title")' });
 		el = screen.getByRole('link');
 		expect(el.title).toBe('title');
 		expect(el.parentElement?.innerHTML).toMatchInlineSnapshot(
-			'"test <!--<Renderer>--><a href=\\"https://ssssota.github.io\\" title=\\"title\\">link<!--<Renderer>--></a><!--<Renderer>-->"'
+			'"test <!--<Renderer>--><a href=\\"https://ssssota.github.io\\" title=\\"title\\">link<!--<Renderer>--></a><!--<Element>--><!--<Renderer>-->"'
 		);
 	});
 
@@ -144,7 +144,7 @@ describe('Markdown(CommonMark)', () => {
 		const el = screen.getByText('code');
 		expect(el.tagName.toLowerCase()).toBe('code');
 		expect(el.parentElement?.innerHTML).toMatchInlineSnapshot(
-			'"test <!--<Renderer>--><code>code<!--<Renderer>--></code><!--<Renderer>-->"'
+			'"test <!--<Renderer>--><code>code<!--<Renderer>--></code><!--<Element>--><!--<Renderer>-->"'
 		);
 	});
 
@@ -160,7 +160,7 @@ describe('Markdown(CommonMark)', () => {
 			"<pre><code>const square = (x: number) =&gt; {
 			  return x * x;
 			};
-			<!--<Renderer>--></code><!--<Renderer>--></pre>"
+			<!--<Renderer>--></code><!--<Element>--><!--<Renderer>--></pre>"
 		`);
 
 		ctx.rerender({ md: '```js\nconst val = 1;\n```' });
@@ -168,7 +168,7 @@ describe('Markdown(CommonMark)', () => {
 		expect(el.className).toBe('language-js');
 		expect(el.parentElement?.outerHTML).toMatchInlineSnapshot(`
 			"<pre><code class=\\"language-js\\">const val = 1;
-			<!--<Renderer>--></code><!--<Renderer>--></pre>"
+			<!--<Renderer>--></code><!--<Element>--><!--<Renderer>--></pre>"
 		`);
 
 		ctx.rerender({ md: '~~~js\nconst val = `2`;\n~~~' });
@@ -176,7 +176,7 @@ describe('Markdown(CommonMark)', () => {
 		expect(el.className).toBe('language-js');
 		expect(el.parentElement?.outerHTML).toMatchInlineSnapshot(`
 			"<pre><code class=\\"language-js\\">const val = \`2\`;
-			<!--<Renderer>--></code><!--<Renderer>--></pre>"
+			<!--<Renderer>--></code><!--<Element>--><!--<Renderer>--></pre>"
 		`);
 	});
 
@@ -187,7 +187,7 @@ describe('Markdown(CommonMark)', () => {
 		expect(p1.parentElement?.tagName.toLowerCase()).toBe('blockquote');
 		expect(p1.parentElement?.outerHTML).toMatchInlineSnapshot(`
 			"<blockquote>
-			<!--<Renderer>--><p>test<!--<Renderer>--></p><!--<Renderer>-->
+			<!--<Renderer>--><p>test<!--<Renderer>--></p><!--<Element>--><!--<Renderer>-->
 			<!--<Renderer>--></blockquote>"
 		`);
 
@@ -198,10 +198,10 @@ describe('Markdown(CommonMark)', () => {
 		expect(p3.parentElement?.parentElement).toBe(p2.parentElement);
 		expect(p2.parentElement?.outerHTML).toMatchInlineSnapshot(`
 			"<blockquote>
-			<!--<Renderer>--><p>top<!--<Renderer>--></p><!--<Renderer>-->
+			<!--<Renderer>--><p>top<!--<Renderer>--></p><!--<Element>--><!--<Renderer>-->
 			<!--<Renderer>--><blockquote>
-			<!--<Renderer>--><p>nested<!--<Renderer>--></p><!--<Renderer>-->
-			<!--<Renderer>--></blockquote><!--<Renderer>-->
+			<!--<Renderer>--><p>nested<!--<Renderer>--></p><!--<Element>--><!--<Renderer>-->
+			<!--<Renderer>--></blockquote><!--<Element>--><!--<Renderer>-->
 			<!--<Renderer>--></blockquote>"
 		`);
 	});
@@ -256,14 +256,14 @@ describe('Markdown(CommonMark)', () => {
 	it('should render themantic break', () => {
 		const ctx = render(Markdown, { md: '----------' });
 		expect(ctx.container.innerHTML).toMatchInlineSnapshot(
-			'"<div><hr><!--<Renderer>--><!--<Renderer>--><!--<Markdown>--></div>"'
+			'"<div><hr><!--<Element>--><!--<Renderer>--><!--<Renderer>--><!--<Markdown>--></div>"'
 		);
 
 		ctx.rerender({ md: '***\n---\n___' });
 		expect(ctx.container.innerHTML).toMatchInlineSnapshot(`
-			"<div><hr><!--<Renderer>-->
-			<!--<Renderer>--><hr><!--<Renderer>-->
-			<!--<Renderer>--><hr><!--<Renderer>--><!--<Renderer>--><!--<Markdown>--></div>"
+			"<div><hr><!--<Element>--><!--<Renderer>-->
+			<!--<Renderer>--><hr><!--<Element>--><!--<Renderer>-->
+			<!--<Renderer>--><hr><!--<Element>--><!--<Renderer>--><!--<Renderer>--><!--<Markdown>--></div>"
 		`);
 	});
 
@@ -307,7 +307,7 @@ describe('HTML', () => {
 		});
 		expect(container.innerHTML.includes('<br>')).toBe(true);
 		expect(container.innerHTML).toMatchInlineSnapshot(
-			'"<div><p>a<!--<Renderer>--><br><!--<Renderer>-->b<!--<Renderer>--></p><!--<Renderer>--><!--<Renderer>--><!--<Markdown>--></div>"'
+			'"<div><p>a<!--<Renderer>--><br><!--<Element>--><!--<Renderer>-->b<!--<Renderer>--></p><!--<Element>--><!--<Renderer>--><!--<Renderer>--><!--<Markdown>--></div>"'
 		);
 	});
 });

--- a/src/tests/Transparent.test.ts
+++ b/src/tests/Transparent.test.ts
@@ -20,6 +20,6 @@ it('should not render children', () => {
 		plugins: [{ renderer: { em: Transparent } }]
 	});
 	expect(ctx.container.children[0]?.innerHTML).toMatchInlineSnapshot(
-		'"<p>test <!--<Renderer>-->em<!--<Renderer>--><!--<Transparent>--><!--<Renderer>--></p><!--<Renderer>--><!--<Renderer>--><!--<Markdown>-->"'
+		'"<p>test <!--<Renderer>-->em<!--<Renderer>--><!--<Transparent>--><!--<Renderer>--></p><!--<Element>--><!--<Renderer>--><!--<Renderer>--><!--<Markdown>-->"'
 	);
 });

--- a/src/tests/allowlist.test.ts
+++ b/src/tests/allowlist.test.ts
@@ -11,7 +11,7 @@ it('should render paragraph instead of h1', () => {
 	});
 
 	expect(ctx.container.innerHTML).toMatchInlineSnapshot(`
-		"<div><h1>test<!--<Renderer>--></h1><!--<Renderer>-->
+		"<div><h1>test<!--<Renderer>--></h1><!--<Element>--><!--<Renderer>-->
 		<!--<Renderer>--><!--<Renderer>--><!--<Renderer>--><!--<Markdown>--></div>"
 	`);
 });

--- a/src/tests/denylist.test.ts
+++ b/src/tests/denylist.test.ts
@@ -11,7 +11,7 @@ it('should render paragraph instead of h1', () => {
 	});
 
 	expect(ctx.container.innerHTML).toMatchInlineSnapshot(`
-		"<div><h1>test<!--<Renderer>--></h1><!--<Renderer>-->
+		"<div><h1>test<!--<Renderer>--></h1><!--<Element>--><!--<Renderer>-->
 		<!--<Renderer>--><!--<Renderer>--><!--<Renderer>--><!--<Markdown>--></div>"
 	`);
 });

--- a/src/tests/element.test.ts
+++ b/src/tests/element.test.ts
@@ -11,7 +11,7 @@ it('should render paragraph instead of h1', () => {
 	});
 
 	expect(ctx.container.innerHTML).toMatchInlineSnapshot(
-		'"<div><p>test<!--<Renderer>--></p><!--<Renderer>--><!--<Renderer>--><!--<Markdown>--></div>"'
+		'"<div><p>test<!--<Renderer>--></p><!--<Element>--><!--<Renderer>--><!--<Renderer>--><!--<Markdown>--></div>"'
 	);
 });
 


### PR DESCRIPTION
This is to resolve Katex SVG render issues caused by invalid namespace for SVG components.

It will add the below to components of svg and path type to resolve render issue.

```svelte
<svelte:options namespace="svg" />
```

Resolves: https://github.com/ssssota/svelte-exmarkdown/issues/123
