### PR TITLE
Add custom remark2rehype handlers

### DIFF
--- a/.changeset/brown-suns-sin.md
+++ b/.changeset/brown-suns-sin.md
@@ -1,0 +1,5 @@
+---
+"svelte-exmarkdown": minor
+---
+
+Adds the ability for plugins to pass down handlers to remark2rehype

--- a/.changeset/brown-suns-sin.md
+++ b/.changeset/brown-suns-sin.md
@@ -2,4 +2,4 @@
 "svelte-exmarkdown": minor
 ---
 
-Adds the ability for plugins to pass down handlers to remark2rehype
+Adds the ability for plugins to pass down options to remark2rehype

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"highlightjs-svelte": "^1.0.6",
 		"jsdom": "^24.0.0",
 		"katex": "^0.16.9",
+		"mdast-util-to-hast": "^13.2.0",
 		"mermaid": "^10.7.0",
 		"prettier": "^3.2.4",
 		"prettier-plugin-svelte": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
 		"highlightjs-svelte": "^1.0.6",
 		"jsdom": "^24.0.0",
 		"katex": "^0.16.9",
-		"mdast-util-to-hast": "^13.2.0",
 		"mermaid": "^10.7.0",
 		"prettier": "^3.2.4",
 		"prettier-plugin-svelte": "^3.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       katex:
         specifier: ^0.16.9
         version: 0.16.10
+      mdast-util-to-hast:
+        specifier: ^13.2.0
+        version: 13.2.0
       mermaid:
         specifier: ^10.7.0
         version: 10.9.0
@@ -2109,11 +2112,8 @@ packages:
   mdast-util-phrasing@4.0.0:
     resolution: {integrity: sha512-xadSsJayQIucJ9n053dfQwVu1kuXg7jCTdYsMK8rqzKZh52nLfSH/k0sAxE0u+pj/zKZX+o5wB+ML5mRayOxFA==}
 
-  mdast-util-to-hast@13.0.2:
-    resolution: {integrity: sha512-U5I+500EOOw9e3ZrclN3Is3fRpw8c19SMyNZlZ2IS+7vLsNzb2Om11VpIVOR+/0137GhZsFEF6YiKD5+0Hr2Og==}
-
-  mdast-util-to-hast@13.1.0:
-    resolution: {integrity: sha512-/e2l/6+OdGp/FB+ctrJ9Avz71AN/GRH3oi/3KAx/kMnoUsD6q0woXlDT8lLEeViVKE7oZxE7RXzvO3T8kF2/sA==}
+  mdast-util-to-hast@13.2.0:
+    resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
 
   mdast-util-to-markdown@2.1.0:
     resolution: {integrity: sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==}
@@ -5257,7 +5257,7 @@ snapshots:
       hast-util-from-parse5: 8.0.1
       hast-util-to-parse5: 8.0.0
       html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.0.2
+      mdast-util-to-hast: 13.2.0
       parse5: 7.1.2
       unist-util-position: 5.0.0
       unist-util-visit: 5.0.0
@@ -5782,18 +5782,7 @@ snapshots:
       '@types/mdast': 4.0.3
       unist-util-is: 6.0.0
 
-  mdast-util-to-hast@13.0.2:
-    dependencies:
-      '@types/hast': 3.0.1
-      '@types/mdast': 4.0.3
-      '@ungap/structured-clone': 1.2.0
-      devlop: 1.1.0
-      micromark-util-sanitize-uri: 2.0.0
-      trim-lines: 3.0.1
-      unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
-
-  mdast-util-to-hast@13.1.0:
+  mdast-util-to-hast@13.2.0:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.3
@@ -6609,7 +6598,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.3
-      mdast-util-to-hast: 13.1.0
+      mdast-util-to-hast: 13.2.0
       unified: 11.0.4
       vfile: 6.0.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,9 +87,6 @@ importers:
       katex:
         specifier: ^0.16.9
         version: 0.16.10
-      mdast-util-to-hast:
-        specifier: ^13.2.0
-        version: 13.2.0
       mermaid:
         specifier: ^10.7.0
         version: 10.9.0

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,7 +11,7 @@ export type Plugin = {
 	remarkPlugin?: Pluggable;
 	rehypePlugin?: Pluggable;
 	renderer?: ComponentsMap;
-	remarkToRehypeOptions?: Options
+	remarkToRehypeOptions?: Options;
 };
 
 export type UnistNode = ReturnType<Processor['parse']> & {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,6 @@
 import type { ComponentType, SvelteComponent } from 'svelte';
 import type { Pluggable, Processor } from 'unified';
+import type { Handlers } from 'mdast-util-to-hast';
 
 export type Component = ComponentType<SvelteComponent>;
 export type ComponentsMap = Record<
@@ -10,6 +11,7 @@ export type Plugin = {
 	remarkPlugin?: Pluggable;
 	rehypePlugin?: Pluggable;
 	renderer?: ComponentsMap;
+	handler?: Handlers
 };
 
 export type UnistNode = ReturnType<Processor['parse']> & {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,6 @@
 import type { ComponentType, SvelteComponent } from 'svelte';
 import type { Pluggable, Processor } from 'unified';
-import type { Handlers } from 'mdast-util-to-hast';
+import type { Options } from 'remark-rehype';
 
 export type Component = ComponentType<SvelteComponent>;
 export type ComponentsMap = Record<
@@ -11,7 +11,7 @@ export type Plugin = {
 	remarkPlugin?: Pluggable;
 	rehypePlugin?: Pluggable;
 	renderer?: ComponentsMap;
-	handler?: Handlers
+	remarkToRehypeOptions?: Options
 };
 
 export type UnistNode = ReturnType<Processor['parse']> & {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -70,10 +70,10 @@ function fakeDeepMerge<T, K extends keyof T>(agg: T, cur: T, k: K, def: T[K]) {
 	agg[k] ??= def;
 	// Casting here helps avoid adding a billion lines of ts to determine if T[K] is truly an iterable
 	// This is used only internally so its ok to not truly be 'safe'
-	agg[k] = [
-		...(agg[k] as Iterable<unknown>),
+	agg[k] = (Array.isArray(agg[k]) ? [
+		...agg[k],
 		...(cur[k] as unknown as Iterable<unknown>)
-	] as T[K];
+	] : {...agg[k], ...cur[k]}) as T[K];
 	delete cur[k];
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -64,7 +64,10 @@ export const createParser = (plugins: Plugin[]): Parser => {
 	const processor = unified()
 		.use(remarkParse)
 		.use(plugins.map((plugin) => plugin.remarkPlugin).filter(nonNullable))
-		.use(remarkRehype, { allowDangerousHtml: true })
+		.use(remarkRehype, {
+			allowDangerousHtml: true,
+			handlers: plugins.map((plugin) => plugin.handler).filter(nonNullable).reduce((memo, cur) => ({...memo, ...cur}), {})
+		})
 		.use(plugins.map((plugin) => plugin.rehypePlugin).filter(nonNullable))
 		.use(rehypeReactPropsToSvelteProps);
 	return (md: string) => processor.runSync(processor.parse(md), md);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -70,10 +70,11 @@ function fakeDeepMerge<T, K extends keyof T>(agg: T, cur: T, k: K, def: T[K]) {
 	agg[k] ??= def;
 	// Casting here helps avoid adding a billion lines of ts to determine if T[K] is truly an iterable
 	// This is used only internally so its ok to not truly be 'safe'
-	agg[k] = (Array.isArray(agg[k]) ? [
-		...agg[k],
-		...(cur[k] as unknown as Iterable<unknown>)
-	] : {...agg[k], ...cur[k]}) as T[K];
+	agg[k] = (
+		Array.isArray(agg[k])
+			? [...agg[k], ...(cur[k] as unknown as Iterable<unknown>)]
+			: { ...agg[k], ...cur[k] }
+	) as T[K];
 	delete cur[k];
 }
 


### PR DESCRIPTION
Fixes #260

As a note - this looks like it adds a new dep `mdast-util-to-hast`. However, this actually just moves it out of the dependency of another pkg.