### PR TITLE
Ensure custom renderers are used during SSR

### DIFF
--- a/.changeset/pink-flowers-trade.md
+++ b/.changeset/pink-flowers-trade.md
@@ -1,0 +1,5 @@
+---
+"svelte-exmarkdown": patch
+---
+
+Ensure custom renderers are used during SSR

--- a/src/lib/Markdown.svelte
+++ b/src/lib/Markdown.svelte
@@ -5,7 +5,7 @@
 	} from './contexts';
 	import Renderer from './Renderer.svelte';
 	import type { HastNode, Parser, Plugin } from './types';
-	import { createParser, nonNullable } from './utils';
+	import { createParser, getComponentsFromPlugins } from './utils';
 
 	type Props = {
 		md: string;
@@ -15,14 +15,11 @@
 
 	let parse = $derived<Parser>(createParser(plugins));
 
-	const componentsContextValue = createComponentsContextValue({});
+	const componentsContextValue = createComponentsContextValue(
+		getComponentsFromPlugins(plugins)
+	);
 	$effect(() => {
-		componentsContextValue.set({
-			...plugins
-				.map((plugin) => plugin.renderer)
-				.filter(nonNullable)
-				.reduce((acc, cur) => ({ ...acc, ...cur }), {})
-		});
+		componentsContextValue.set(getComponentsFromPlugins(plugins));
 	});
 	setComponentsContext(componentsContextValue);
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -90,12 +90,12 @@ export const resolveComponent = (
 	return component;
 };
 
-export const getComponentsFromPlugins = (plugins: Plugin[])=> {
+export const getComponentsFromPlugins = (plugins: Plugin[]) => {
 	return plugins
 		.map((plugin) => plugin.renderer)
 		.filter(nonNullable)
 		.reduce((acc, cur) => ({ ...acc, ...cur }), {});
-}
+};
 
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element
@@ -176,4 +176,3 @@ export const allowlist = (tags: Tag[]): Plugin => ({
 export const denylist = (tags: Tag[]): Plugin => ({
 	renderer: Object.fromEntries(tags.map((tag) => [tag, null]))
 });
-

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -90,6 +90,13 @@ export const resolveComponent = (
 	return component;
 };
 
+export const getComponentsFromPlugins = (plugins: Plugin[])=> {
+	return plugins
+		.map((plugin) => plugin.renderer)
+		.filter(nonNullable)
+		.reduce((acc, cur) => ({ ...acc, ...cur }), {});
+}
+
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element
  */
@@ -169,3 +176,4 @@ export const allowlist = (tags: Tag[]): Plugin => ({
 export const denylist = (tags: Tag[]): Plugin => ({
 	renderer: Object.fromEntries(tags.map((tag) => [tag, null]))
 });
+

--- a/src/tests/element.test.ts
+++ b/src/tests/element.test.ts
@@ -20,7 +20,14 @@ it('should throw error because circular reference', () => {
 			plugins: [{ renderer: { h1: 'h1' } }]
 		})
 	).toThrowErrorMatchingInlineSnapshot(
-		`[Error: Circular dependency detected: h1 -> h1]`
+		`
+		[Error: Circular dependency detected: h1 -> h1
+
+			in Renderer.svelte
+			in Renderer.svelte
+			in Markdown.svelte
+		]
+	`
 	);
 
 	expect(() =>
@@ -29,6 +36,13 @@ it('should throw error because circular reference', () => {
 			plugins: [{ renderer: { h1: 'h2', h2: 'h1' } }]
 		})
 	).toThrowErrorMatchingInlineSnapshot(
-		`[Error: Circular dependency detected: h1 -> h2 -> h1]`
+		`
+		[Error: Circular dependency detected: h1 -> h2 -> h1
+
+			in Renderer.svelte
+			in Renderer.svelte
+			in Markdown.svelte
+		]
+	`
 	);
 });


### PR DESCRIPTION
As of now SSR with custom renderers is broken. You can go to the documentation, disable JS in browser and see empty blocks on all examples. My problem was not in empty blocks but in my custom renderers not being used in SSR. 

Seems like this is because first value (during SSR) of `componentsContextValue` is `{}` and Svelte 5 runs `$effect()` only in browser (I remember reading something metioning this during Svelte 5 beta months, but can't find any quotes about this now) so only in browser it is overridden with correct object based on `plugins` prop. 

I tried _initializing_ context with correct object immediately and extracted a function creating this object to utils to avoid duplication. Both Docs blocks and custom renderers in my project started working in SSR too. 

## Server Rendered Page:

| Before | After |
| --- | --- |
|  <img width="849" alt="Знімок екрана 2024-12-03 о 02 52 36" src="https://github.com/user-attachments/assets/30b1ce0d-e00e-4e5d-9b0e-2c2832baa014"> | <img width="715" alt="Знімок екрана 2024-12-03 о 02 53 29" src="https://github.com/user-attachments/assets/9724bfee-1995-4a5b-8762-8777e9d3e344"> |