### PR TITLE
refactor: migrate to Svelte 5 reactive primitives

### DIFF
--- a/.changeset/wise-ants-change.md
+++ b/.changeset/wise-ants-change.md
@@ -1,0 +1,5 @@
+---
+"svelte-exmarkdown": major
+---
+
+Change API to access AST nodes

--- a/src/lib/Markdown.svelte
+++ b/src/lib/Markdown.svelte
@@ -2,7 +2,7 @@
 	import {
 		createComponentsContextValue,
 		setComponentsContext
-	} from './contexts';
+	} from './contexts.svelte';
 	import Renderer from './Renderer.svelte';
 	import type { HastNode, Parser, Plugin } from './types';
 	import { createParser, getComponentsFromPlugins } from './utils';
@@ -19,7 +19,7 @@
 		getComponentsFromPlugins(plugins)
 	);
 	$effect(() => {
-		componentsContextValue.set(getComponentsFromPlugins(plugins));
+		componentsContextValue.current = getComponentsFromPlugins(plugins);
 	});
 	setComponentsContext(componentsContextValue);
 

--- a/src/lib/Renderer.svelte
+++ b/src/lib/Renderer.svelte
@@ -4,7 +4,7 @@
 		createAstContextValue,
 		getComponentsMap,
 		setAstContext
-	} from './contexts';
+	} from './contexts.svelte';
 	import type { HastNode } from './types';
 	import { isSvgTag, resolveComponent } from './utils';
 	type Props = {
@@ -16,44 +16,56 @@
 
 	const astContext = createAstContextValue(astNode);
 	$effect(() => {
-		astContext.set(astNode);
+		astContext.current = astNode;
 	});
 	setAstContext(astContext);
-
-	// HACK: This looks like the worst formatting, but it prevents the library from rendering unexpected spaces.
 </script>
 
-{#if astNode.type === 'root'}{#each astNode.children as child}<Renderer
-			astNode={child}
-		/>{/each}{:else if astNode.type === 'element'}{@const Component =
-		resolveComponent(
-			$components,
-			astNode.tagName
-		)}{#if typeof Component === 'string'}{#if isSvgTag(Component)}{#if Array.isArray(astNode.children) && astNode.children.length !== 0}<svelte:element
+{#if astNode.type === 'root'}
+	{#each astNode.children as child}
+		<Renderer astNode={child} />
+	{/each}
+{:else if astNode.type === 'element'}
+	{@const Component = resolveComponent(components.current, astNode.tagName)}
+	{#if typeof Component === 'string'}
+		{#if isSvgTag(Component)}
+			{#if Array.isArray(astNode.children) && astNode.children.length !== 0}
+				<svelte:element
 					this={Component}
 					xmlns="http://www.w3.org/2000/svg"
 					{...astNode.properties}
-					>{#each astNode.children as child}<Renderer
-							astNode={child}
-						/>{/each}</svelte:element
-				>{:else}<svelte:element
+				>
+					{#each astNode.children as child}
+						<Renderer astNode={child} />
+					{/each}
+				</svelte:element>
+			{:else}
+				<svelte:element
 					this={Component}
 					xmlns="http://www.w3.org/2000/svg"
 					{...astNode.properties}
-				/>{/if}{:else if Array.isArray(astNode.children) && astNode.children.length !== 0}<svelte:element
-				this={Component}
-				{...astNode.properties}
-				>{#each astNode.children as child}<Renderer
-						astNode={child}
-					/>{/each}</svelte:element
-			>{:else}<svelte:element
-				this={Component}
-				{...astNode.properties}
-			/>{/if}{:else if Component !== null}{#if Array.isArray(astNode.children) && astNode.children.length !== 0}<Component
-				{...astNode.properties}
-				>{#each astNode.children as child}<Renderer
-						astNode={child}
-					/>{/each}</Component
-			>{:else}<Component
-				{...astNode.properties}
-			/>{/if}{/if}{:else if astNode.type === 'text' || astNode.type === 'raw'}{astNode.value}{/if}
+				/>
+			{/if}
+		{:else if Array.isArray(astNode.children) && astNode.children.length !== 0}
+			<svelte:element this={Component} {...astNode.properties}>
+				{#each astNode.children as child}
+					<Renderer astNode={child} />
+				{/each}
+			</svelte:element>
+		{:else}
+			<svelte:element this={Component} {...astNode.properties} />
+		{/if}
+	{:else if Component !== null}
+		{#if Array.isArray(astNode.children) && astNode.children.length !== 0}
+			<Component {...astNode.properties}>
+				{#each astNode.children as child}
+					<Renderer astNode={child} />
+				{/each}
+			</Component>
+		{:else}
+			<Component {...astNode.properties} />
+		{/if}
+	{/if}
+{:else if astNode.type === 'text' || astNode.type === 'raw'}
+	{astNode.value}
+{/if}

--- a/src/lib/contexts.svelte.ts
+++ b/src/lib/contexts.svelte.ts
@@ -1,22 +1,37 @@
 import { getContext, setContext } from 'svelte';
-import { writable, type Readable } from 'svelte/store';
-import type { ComponentsMap, HastNode } from './types';
+import type { ComponentsMap, HastNode, Readable } from './types';
 
 const componentsContextKey = 'components';
 export const getComponentsMap = () =>
 	getContext<Readable<ComponentsMap>>(componentsContextKey);
 export const setComponentsContext = (value: Readable<ComponentsMap>) =>
 	setContext(componentsContextKey, value);
+
 export const createComponentsContextValue = (init: ComponentsMap) => {
-	const { set, subscribe } = writable(init);
-	return { set, subscribe };
+	let value = $state(init);
+	return {
+		set current(components: ComponentsMap) {
+			value = components;
+		},
+		get current() {
+			return value;
+		}
+	};
 };
 
 const astContextKey = 'ast';
 export const getAstNode = () => getContext<Readable<HastNode>>(astContextKey);
 export const setAstContext = (value: Readable<HastNode>) =>
 	setContext(astContextKey, value);
+
 export const createAstContextValue = (init: HastNode) => {
-	const { set, subscribe } = writable(init);
-	return { set, subscribe };
+	let value = $state(init);
+	return {
+		set current(node: HastNode) {
+			value = node;
+		},
+		get current() {
+			return value;
+		}
+	};
 };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,8 +1,8 @@
 import Markdown from './Markdown.svelte';
 
+export { getAstNode } from './contexts.svelte';
 export { default as Renderer } from './Renderer.svelte';
 export { default as Transparent } from './Transparent.svelte';
-export { getAstNode } from './contexts';
 export type * from './types';
 export { allowlist, denylist } from './utils';
 export { Markdown };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -50,3 +50,7 @@ export type HastNode =
 	| HastRaw;
 
 export type Parser = (md: string) => UnistNode;
+export type Readable<T> = {
+	get current(): T;
+	set current(value: T);
+};

--- a/src/routes/docs/_example/DumpAst.svelte
+++ b/src/routes/docs/_example/DumpAst.svelte
@@ -5,4 +5,4 @@
 </script>
 
 <!-- Dump current node -->
-<pre>{JSON.stringify($astContext, null, 2)}</pre>
+<pre>{JSON.stringify(astContext.current, null, 2)}</pre>

--- a/src/routes/docs/_mermaid/Code.svelte
+++ b/src/routes/docs/_mermaid/Code.svelte
@@ -1,20 +1,28 @@
 <script lang="ts">
-	import { getAstNode } from '$lib/contexts';
+	import { getAstNode } from '$lib/contexts.svelte';
 	import mermaid from 'mermaid';
-	let source: HTMLElement | null = null;
+	let source: HTMLElement | null = $state(null);
 	const ast = getAstNode();
 
-	let isMermaid = false;
-	$: isMermaid =
-		typeof $ast.properties?.class === 'string' &&
-		$ast.properties.class.split(/\s+/g).includes('language-mermaid');
-	$: if (isMermaid && source) mermaid.run({ nodes: [source] });
+	let { children, ...props } = $props();
+
+	const isMermaid = $derived(
+		typeof ast.current.properties?.class === 'string' &&
+			ast.current.properties.class.split(/\s+/g).includes('language-mermaid')
+	);
+	$effect(() => {
+		if (isMermaid && source) mermaid.run({ nodes: [source] });
+	});
 </script>
 
 {#if isMermaid}
-	{#key $ast.children?.[0]?.value}
-		<div {...$$props} bind:this={source}>{$ast.children?.[0]?.value ?? ''}</div>
+	{#key ast.current.children?.[0]?.value}
+		<div {...props} bind:this={source}>
+			{ast.current.children?.[0]?.value ?? ''}
+		</div>
 	{/key}
 {:else}
-	<code {...$$props}><slot /></code>
+	<code {...props}>
+		{@render children()}
+	</code>
 {/if}

--- a/src/tests/RenderAstNode.svelte
+++ b/src/tests/RenderAstNode.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { getAstNode } from '../lib/contexts';
+	import { getAstNode } from '../lib/contexts.svelte';
 	const ast = getAstNode();
 </script>
 
-<output>{JSON.stringify($ast)}</output>
+<output>{JSON.stringify(ast.current)}</output>


### PR DESCRIPTION
@ssssota Please check that [src/lib/Renderer.svelte](https://github.com/ssssota/svelte-exmarkdown/compare/main...HanielU:svelte-exmarkdown:main#diff-66c788b28e11916aeeef08e9ce2e6a3d81321d719cc8493f286ad86d4733e343) doesn't cause any unexpected bugs.

From my testing, whatever issues you were having with the old formatting is gone in svelte 5.

Changes:

- Renamed `contexts.ts` to `contexts.svelte`
- Updated context handling to use Svelte 5 state and derived primitives
- Replaced `$:` reactive statements with `$derived` and `$effect`
- Modified context value access from `.set()` to `.current`
- Updated type definitions to support new reactive primitive pattern
- Refactored component rendering to use new reactive primitives