### PR TITLE
Using effect.pre to prevent maximum update depth when in loop

### DIFF
--- a/.changeset/shy-rockets-remember.md
+++ b/.changeset/shy-rockets-remember.md
@@ -1,0 +1,5 @@
+---
+"svelte-exmarkdown": patch
+---
+
+fix: use effect.pre to prevent maximum update depth when in loop

--- a/src/lib/Renderer.svelte
+++ b/src/lib/Renderer.svelte
@@ -13,7 +13,7 @@
 	const components = getComponentsMap();
 
 	const astContext = ref(astNode);
-	$effect(() => {
+	$effect.pre(() => {
 		astContext.current = astNode;
 	});
 	setAstContext(astContext);

--- a/src/lib/Renderer.svelte
+++ b/src/lib/Renderer.svelte
@@ -14,7 +14,10 @@
 
 	const astContext = ref(astNode);
 	$effect.pre(() => {
-		astContext.current = astNode;
+		// Pre-flush to mirror astNode into context without triggering another flush cycle
+		if (astContext.current !== astNode) {
+			astContext.current = astNode;
+		}
 	});
 	setAstContext(astContext);
 

--- a/src/lib/Renderer.svelte
+++ b/src/lib/Renderer.svelte
@@ -14,10 +14,7 @@
 
 	const astContext = ref(astNode);
 	$effect.pre(() => {
-		// Pre-flush to mirror astNode into context without triggering another flush cycle
-		if (astContext.current !== astNode) {
-			astContext.current = astNode;
-		}
+		astContext.current = astNode;
 	});
 	setAstContext(astContext);
 


### PR DESCRIPTION
Based on new issue we are having this seems like a quick fix.
```svelte
$effect.pre(() => {
  astContext.current = astNode;
});
```

This seem to fix the effect_update_depth_exceeded error when you have multiple <Markdown /> components in a loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary updates for improved efficiency and responsiveness.
  * Fixed an update loop issue to prevent maximum update depth errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->